### PR TITLE
Add detailed backtest performance results in CLI

### DIFF
--- a/src/Domain/Backtesting/Event/BacktestPhaseEvent.php
+++ b/src/Domain/Backtesting/Event/BacktestPhaseEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Stochastix\Domain\Backtesting\Event;
+
+namespace Stochastix\Domain\Backtesting\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class BacktestPhaseEvent extends Event
+{
+    public function __construct(
+        public readonly string $runId,
+        public readonly string $phase,
+        public readonly string $eventType,
+    ) {
+    }
+}

--- a/src/Domain/Backtesting/MessageHandler/RunBacktestMessageHandler.php
+++ b/src/Domain/Backtesting/MessageHandler/RunBacktestMessageHandler.php
@@ -50,7 +50,7 @@ final readonly class RunBacktestMessageHandler
                 }
             };
 
-            $results = $this->backtester->run($message->configuration, $progressCallback);
+            $results = $this->backtester->run($message->configuration, $runId, $progressCallback);
 
             $this->resultSaver->save($runId, $results);
 


### PR DESCRIPTION
This PR enhances the `stochastix:backtest` command output with detailed performance results:

```
Execution Profile
-----------------

 ---------------- ----------- ----------
  Phase            Duration    Memory
 ---------------- ----------- ----------
  Configuration    0.30 ms     44.50 MB
  Initialization   33.20 ms    56.50 MB
  Loop             304.10 ms   80.50 MB
  Statistics       971.10 ms   90.50 MB
  Saving           303.90 ms   90.50 MB
 ---------------- ----------- ----------

📊 Backtest finished in: 1612.60 ms / Peak Memory usage: 90.50 MB
```