### PR TITLE
Download data by chunks without redownloading existing data

### DIFF
--- a/config/app.yaml
+++ b/config/app.yaml
@@ -1,4 +1,7 @@
 framework:
+    cache:
+        prefix_seed: 'stochastix.download'
+
     messenger:
         transports:
             stochastix: '%env(MESSENGER_TRANSPORT_DSN)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,3 +16,12 @@ services:
             - '../src/**/Exception'
             - '../src/**/Event'
             - '../src/**/Model'
+
+    stochastix.download.cancel.cache:
+        class: Symfony\Component\Cache\Adapter\FilesystemAdapter
+        arguments:
+            - 'stochastix.download.cancel'
+            - 3600
+            - '%kernel.project_dir%/data/.cache'
+        tags:
+            - { name: 'cache.pool', namespace: 'stochastix.download' }

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,27 @@ This document outlines the RESTful API endpoints provided by the `stochastix-cor
 ---
 ### Market Data
 
+* **`GET /api/data/exchanges`**
+    * **Description:** Retrieves a sorted list of all exchange IDs supported by the backend (via the CCXT library).
+    * **Requires:** None
+    * **Request Body:** None
+    * **Success Response:** `200 OK`
+    * **Example Success Response Body:**
+      ```json
+      [
+          "ace",
+          "alpaca",
+          "ascendex",
+          "bequant",
+          "bigone",
+          "binance",
+          "binancecoinm",
+          "binanceus",
+          "binanceusdm",
+          "bingx"
+      ]
+      ```
+
 * **`GET /api/data-availability`**
     * **Description:** Scans the server for available market data (`.stchx` files) and returns a manifest detailing available symbols, their timeframes, and the start/end dates for each dataset.
     * **Requires:** None

--- a/docs/api.md
+++ b/docs/api.md
@@ -135,6 +135,21 @@ This document outlines the RESTful API endpoints provided by the `stochastix-cor
         * `400 Bad Request`: Invalid input (e.g., validation errors in the request body, end date before start date).
         * `500 Internal Server Error`: If the download message could not be dispatched to the queue.
 
+* **`DELETE /api/data/download/{jobId}`**
+    * **Description:** Requests the cancellation of a running download job. The cancellation may take a few moments to take effect, as it is checked between data chunk fetches.
+    * **Requires:** None
+    * **URL Parameters:**
+        * `jobId` (string, required): The unique ID of the download job to cancel.
+    * **Request Body:** None
+    * **Success Response:** `202 Accepted`
+    * **Example Success Response Body:**
+        ```json
+        {
+          "status": "cancellation_requested",
+          "jobId": "download_666c1e5a7b8d9"
+        }
+        ```
+    * **Error Responses:** None.
 
 * **`GET /api/data/inspect/{exchangeId}/{symbol}/{timeframe}`**
     * **Description:** Inspects a specific market data file (`.stchx`). Returns the file's header metadata, a sample of the first and last records, and a full data consistency validation report (checking for gaps, duplicates, and out-of-order records).

--- a/src/Command/DataDownloadCommand.php
+++ b/src/Command/DataDownloadCommand.php
@@ -62,6 +62,12 @@ class DataDownloadCommand extends Command
                 'E',
                 InputOption::VALUE_OPTIONAL,
                 'The UTC end date/time (Format: Y-m-d[THH:MM:SS]). Defaults to "now".'
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Force re-download and overwrite of the entire date range, even if data exists.'
             );
     }
 
@@ -74,6 +80,7 @@ class DataDownloadCommand extends Command
             $exchange = $input->getArgument('exchange');
             $symbol = $input->getArgument('symbol');
             $timeframe = $input->getArgument('timeframe');
+            $forceOverwrite = $input->getOption('force');
 
             $startDateStr = $input->getOption('start-date');
             $endDateStr = $input->getOption('end-date');
@@ -87,6 +94,10 @@ class DataDownloadCommand extends Command
                 $io->error('Start date must be strictly before the end date.');
 
                 return Command::INVALID;
+            }
+
+            if ($forceOverwrite) {
+                $io->warning('Force mode enabled: Existing data in the specified range will be overwritten.');
             }
 
             $io->title('🚀 Stochastix OHLCV Data Downloader 🚀');
@@ -116,7 +127,8 @@ class DataDownloadCommand extends Command
                 $symbol,
                 $timeframe,
                 $startDate,
-                $endDate
+                $endDate,
+                $forceOverwrite
             );
 
             $this->progressBar->finish();

--- a/src/Domain/Backtesting/MessageHandler/RunBacktestMessageHandler.php
+++ b/src/Domain/Backtesting/MessageHandler/RunBacktestMessageHandler.php
@@ -76,7 +76,14 @@ final readonly class RunBacktestMessageHandler
 
     private function publishUpdate(string $topic, array $data): void
     {
-        $update = new Update($topic, json_encode($data, JSON_THROW_ON_ERROR));
-        $this->mercureHub->publish($update);
+        try {
+            $update = new Update($topic, json_encode($data, JSON_THROW_ON_ERROR));
+            $this->mercureHub->publish($update);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Failed to publish update to Mercure. The backtest will continue.', [
+                'topic' => $topic,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/src/Domain/Backtesting/Service/MultiTimeframeDataService.php
+++ b/src/Domain/Backtesting/Service/MultiTimeframeDataService.php
@@ -70,7 +70,7 @@ final readonly class MultiTimeframeDataService implements MultiTimeframeDataServ
             rtrim($this->baseDataPath, '/'),
             strtolower($exchangeId),
             strtoupper($sanitizedSymbol),
-            strtolower($timeframe)
+            $timeframe
         );
     }
 }

--- a/src/Domain/Data/Controller/CancelDownloadAction.php
+++ b/src/Domain/Data/Controller/CancelDownloadAction.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Stochastix\Domain\Data\Controller;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[Route('/api/data/download/{jobId}', name: 'stochastix_api_data_cancel_download', methods: ['DELETE'])]
+class CancelDownloadAction extends AbstractController
+{
+    public function __construct(
+        #[Autowire(service: 'stochastix.download.cancel.cache')]
+        private readonly CacheItemPoolInterface $cache,
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __invoke(string $jobId): JsonResponse
+    {
+        $cacheKey = 'download.cancel.' . $jobId;
+        $item = $this->cache->getItem($cacheKey);
+
+        $item->set(true);
+        $item->expiresAfter(3600);
+        $this->cache->save($item);
+
+        return $this->json(
+            ['status' => 'cancellation_requested', 'jobId' => $jobId],
+            Response::HTTP_ACCEPTED
+        );
+    }
+}

--- a/src/Domain/Data/Controller/GetExchangesAction.php
+++ b/src/Domain/Data/Controller/GetExchangesAction.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stochastix\Domain\Data\Controller;
+
+use Stochastix\Domain\Data\Service\MarketDataService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[Route('/api/data/exchanges', name: 'stochastix_api_data_exchanges', methods: ['GET'])]
+class GetExchangesAction extends AbstractController
+{
+    public function __construct(private readonly MarketDataService $marketDataService)
+    {
+    }
+
+    public function __invoke(): JsonResponse
+    {
+        return $this->json($this->marketDataService->getExchanges());
+    }
+}

--- a/src/Domain/Data/Dto/DownloadRequestDto.php
+++ b/src/Domain/Data/Dto/DownloadRequestDto.php
@@ -20,17 +20,16 @@ class DownloadRequestDto
         public string $startDate,
         #[Assert\Date(message: 'End date must be in Y-m-d format.')]
         public string $endDate,
+        public bool $forceOverwrite = false,
     ) {
     }
 
     public function validateDateRange(ExecutionContextInterface $context): void
     {
-        if ($this->startDate !== null && $this->endDate !== null) {
-            if ($this->endDate < $this->startDate) {
-                $context->buildViolation('End date must be after or the same as start date.')
-                    ->atPath('endDate')
-                    ->addViolation();
-            }
+        if ($this->startDate !== null && $this->endDate !== null && $this->endDate < $this->startDate) {
+            $context->buildViolation('End date must be after or the same as start date.')
+                ->atPath('endDate')
+                ->addViolation();
         }
     }
 }

--- a/src/Domain/Data/Exception/DownloadCancelledException.php
+++ b/src/Domain/Data/Exception/DownloadCancelledException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Stochastix\Domain\Data\Exception;
+
+class DownloadCancelledException extends DownloaderException
+{
+}

--- a/src/Domain/Data/Exception/EmptyHistoryException.php
+++ b/src/Domain/Data/Exception/EmptyHistoryException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Stochastix\Domain\Data\Exception;
+
+class EmptyHistoryException extends ExchangeException
+{
+}

--- a/src/Domain/Data/MessageHandler/DownloadDataMessageHandler.php
+++ b/src/Domain/Data/MessageHandler/DownloadDataMessageHandler.php
@@ -75,7 +75,14 @@ final readonly class DownloadDataMessageHandler
 
     private function publishUpdate(string $topic, array $data): void
     {
-        $update = new Update($topic, json_encode($data, JSON_THROW_ON_ERROR));
-        $this->mercureHub->publish($update);
+        try {
+            $update = new Update($topic, json_encode($data, JSON_THROW_ON_ERROR));
+            $this->mercureHub->publish($update);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Failed to publish update to Mercure. The process will continue.', [
+                'topic' => $topic,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/src/Domain/Data/MessageHandler/DownloadDataMessageHandler.php
+++ b/src/Domain/Data/MessageHandler/DownloadDataMessageHandler.php
@@ -3,6 +3,7 @@
 namespace Stochastix\Domain\Data\MessageHandler;
 
 use Psr\Log\LoggerInterface;
+use Stochastix\Domain\Data\Exception\DownloadCancelledException;
 use Stochastix\Domain\Data\Message\DownloadDataMessage;
 use Stochastix\Domain\Data\Service\OhlcvDownloader;
 use Symfony\Component\Mercure\HubInterface;
@@ -55,6 +56,9 @@ final readonly class DownloadDataMessageHandler
                 'progress' => 100,
                 'message' => 'Download completed successfully.',
             ]);
+        } catch (DownloadCancelledException $e) {
+            $this->logger->info('Data download job {jobId} was cancelled.', ['jobId' => $jobId, 'reason' => $e->getMessage()]);
+            $this->publishUpdate($topic, ['status' => 'cancelled', 'message' => 'Download was cancelled by the user.']);
         } catch (\Throwable $e) {
             $this->logger->error('Data download job {jobId} failed: {message}', [
                 'jobId' => $jobId,

--- a/src/Domain/Data/MessageHandler/DownloadDataMessageHandler.php
+++ b/src/Domain/Data/MessageHandler/DownloadDataMessageHandler.php
@@ -46,6 +46,7 @@ final readonly class DownloadDataMessageHandler
                 $dto->timeframe,
                 $startDate,
                 $endDate,
+                $dto->forceOverwrite,
                 $jobId
             );
 

--- a/src/Domain/Data/Service/BinaryStorageInterface.php
+++ b/src/Domain/Data/Service/BinaryStorageInterface.php
@@ -12,10 +12,6 @@ interface BinaryStorageInterface
 
     public function createFile(string $filePath, string $symbol, string $timeframe): void;
 
-    public function appendRecords(string $filePath, iterable $records): int;
-
-    public function updateRecordCount(string $filePath, int $recordCount): void;
-
     public function readHeader(string $filePath): array;
 
     public function readRecordByIndex(string $filePath, int $index): ?array;
@@ -25,4 +21,14 @@ interface BinaryStorageInterface
     public function mergeAndWrite(string $originalPath, string $newDataPath, string $outputPath): int;
 
     public function readRecordsByTimestampRange(string $filePath, int $startTimestamp, int $endTimestamp): \Generator;
+
+    /**
+     * Streams records from a generator to a file, periodically updating the header's record count.
+     *
+     * @param string   $filePath       The path to the binary file.
+     * @param iterable $records        The records to stream.
+     * @param int      $commitInterval The number of records to write before updating the header.
+     * @return int The total number of records written.
+     */
+    public function streamAndCommitRecords(string $filePath, iterable $records, int $commitInterval = 5000): int;
 }

--- a/src/Domain/Data/Service/MarketDataService.php
+++ b/src/Domain/Data/Service/MarketDataService.php
@@ -2,6 +2,7 @@
 
 namespace Stochastix\Domain\Data\Service;
 
+use ccxt\Exchange;
 use Psr\Cache\InvalidArgumentException;
 use Stochastix\Domain\Data\Exception\ExchangeException;
 use Stochastix\Domain\Data\Service\Exchange\ExchangeFactory;
@@ -53,5 +54,16 @@ final readonly class MarketDataService
                 throw new ExchangeException("Failed to fetch symbols for exchange '{$exchangeId}': " . $e->getMessage(), 0, $e);
             }
         });
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExchanges(): array
+    {
+        $exchanges = Exchange::$exchanges;
+        sort($exchanges);
+
+        return $exchanges;
     }
 }

--- a/src/Domain/Data/Service/OhlcvDownloader.php
+++ b/src/Domain/Data/Service/OhlcvDownloader.php
@@ -3,6 +3,7 @@
 namespace Stochastix\Domain\Data\Service;
 
 use Psr\Log\LoggerInterface;
+use Stochastix\Domain\Data\Exception\DownloadCancelledException;
 use Stochastix\Domain\Data\Exception\DownloaderException;
 use Stochastix\Domain\Data\Exception\EmptyHistoryException;
 use Stochastix\Domain\Data\Service\Exchange\ExchangeAdapterInterface;
@@ -76,6 +77,8 @@ readonly class OhlcvDownloader
             }
 
             return $finalPath;
+        } catch (DownloadCancelledException $e) {
+            throw $e;
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Download failed: {message}.',

--- a/src/Domain/Data/Service/OhlcvDownloader.php
+++ b/src/Domain/Data/Service/OhlcvDownloader.php
@@ -237,7 +237,13 @@ readonly class OhlcvDownloader
     {
         $sanitizedSymbol = str_replace('/', '_', $symbol);
 
-        return sprintf('%s/%s/%s/%s.stchx', rtrim($this->baseDataPath, '/'), strtolower($exchangeId), strtoupper($sanitizedSymbol), $timeframe);
+        return sprintf(
+            '%s/%s/%s/%s.stchx',
+            rtrim($this->baseDataPath, '/'),
+            strtolower($exchangeId),
+            strtoupper($sanitizedSymbol),
+            $timeframe,
+        );
     }
 
     private function cleanupFile(string $filePath, string $reason = ''): void


### PR DESCRIPTION
This PR allows to download "around" an existing dataset.

For example if data exists for the whole month of February and we download new data from January to March, then the downloaded will not redownload February, and patch data together.

Also this PR adds the ability to cancel a download via the API by creating a shared cache entry that the Messenger worker intercepts.